### PR TITLE
Created basic maven project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+/.idea
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # flink-visual-programming
+Simply type
+```mvn jetty:run```
+and the webservice will start at localhost:8080

--- a/client/README.md
+++ b/client/README.md
@@ -1,1 +1,0 @@
-Here shoud be placed the client.

--- a/common/README.md
+++ b/common/README.md
@@ -1,1 +1,0 @@
-Here shoud be placed common used code like component definitions, which are used on the server and on the client.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.tu-berlin.de</groupId>
+    <artifactId>flink-visual-programming</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+        <jetty-version>9.3.6.v20151106</jetty-version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- End Test -->
+
+        <!-- JEE -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <!-- End JEE -->
+
+        <!-- Servlet Container Jetty -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${jetty-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- End Servlet Container Jetty -->
+
+    </dependencies>
+
+    <build>
+        <finalName>FlinkVisualProgramming</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/server/README.md
+++ b/server/README.md
@@ -1,1 +1,0 @@
-Here shoud be placed the backend.

--- a/src/main/java/org/tuberlin/de/client/README.md
+++ b/src/main/java/org/tuberlin/de/client/README.md
@@ -1,0 +1,1 @@
+Here shoud be placed the org.tuberlin.de.client.

--- a/src/main/java/org/tuberlin/de/common/README.md
+++ b/src/main/java/org/tuberlin/de/common/README.md
@@ -1,0 +1,1 @@
+Here shoud be placed common used code like component definitions, which are used on the server and on the org.tuberlin.de.client.

--- a/src/main/java/org/tuberlin/de/server/controller/BaseController.java
+++ b/src/main/java/org/tuberlin/de/server/controller/BaseController.java
@@ -1,0 +1,18 @@
+package org.tuberlin.de.server.controller;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Created by Fabian on 25.11.2015.
+ */
+public class BaseController extends HttpServlet {
+
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws
+		  ServletException, IOException {
+    resp.sendRedirect("/pages/index.html");
+  }
+}

--- a/src/main/java/org/tuberlin/de/server/controller/README.md
+++ b/src/main/java/org/tuberlin/de/server/controller/README.md
@@ -1,0 +1,1 @@
+Here shoud be placed the backend.

--- a/src/main/resources/.gitignore
+++ b/src/main/resources/.gitignore
@@ -1,0 +1,13 @@
+/.idea
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                             http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+    <servlet>
+        <servlet-name>BaseController</servlet-name>
+        <servlet-class>org.tuberlin.de.server.controller.BaseController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>BaseController</servlet-name>
+        <url-pattern>/index</url-pattern>
+    </servlet-mapping>
+    <welcome-file-list>
+        <welcome-file>/pages/index.html</welcome-file>
+    </welcome-file-list>
+
+</web-app>

--- a/src/main/webapp/javascript/README.md
+++ b/src/main/webapp/javascript/README.md
@@ -1,0 +1,1 @@
+Here all client-side javascript files should be placed (e.g. jointJS)

--- a/src/main/webapp/pages/README.md
+++ b/src/main/webapp/pages/README.md
@@ -1,0 +1,1 @@
+Here all HTML Files should be placed.

--- a/src/main/webapp/pages/index.html
+++ b/src/main/webapp/pages/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Flink Visual programming</title>
+</head>
+<body>
+    <h1>This is going to be Flink Visual Programming</h1>
+</body>
+</html>

--- a/src/test/java/.gitignore
+++ b/src/test/java/.gitignore
@@ -1,0 +1,13 @@
+/.idea
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
This commit introduces our basic maven project structure.
We have decided to use simple Java Servlets + Jetty as webserver for the following reasons:
- very simple configuration
- very simple complexity
- we don't use much of more advanced web framework (e.g. Spring) capabilities, must of our stuff is client side (HTML and JavaScript) and the Code generation & Deployment. In both areas we don't need a complex web framework.

Simply type ```mvn jetty:run``` and the website will be deployed at localhost:8080