### PR TITLE
Added 'dev' profile to maven for serving grunt locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CIT Project - Flink-visual-programming
 
-[![Jenkins Build Status](http://asok16.cit.tu-berlin.de:8080/buildStatus/icon?job=flink-visual)](http://asok16.cit.tu-berlin.de:8080/job/flink-visual/) 
+**Master branch:** [![Jenkins Build Status Master](http://asok16.cit.tu-berlin.de:8080/buildStatus/icon?job=flink-visual)](http://asok16.cit.tu-berlin.de:8080/job/flink-visual/) 
+**Dev branch:** [![Jenkins Build Status Dev](http://asok16.cit.tu-berlin.de:8080/buildStatus/icon?job=flink-visual-dev)](http://asok16.cit.tu-berlin.de:8080/job/flink-visual-dev/) 
 
 The Master Project from the departmend Complex and Distributed IT Systems @TU Berlin -
 [More information](https://www.cit.tu-berlin.de/menue/teaching/wintersemester_1516/master_projekt_verteilte_systeme/)
@@ -9,12 +10,18 @@ The task is to create a visual programming environment for [Apache Flink](https:
 
 ## Run the project
 
-Simply type
-```mvn jetty:run```
-and the webservice will start at `localhost:8080`.
+Simply type `mvn jetty:run` and the jetty server will start at `localhost:8080`.
+
+For local frontent development it might be easier to use `grunt serve` for hosting only the website locally instead of the whole jetty environment. 
+This is possible via the maven `dev` profile. Simply run `mvn jetty:run -P dev`, which will handle everything for you.
+**Caution** - This will only start the frontend, not the backend.
 
 ## Jenkins
 
-The most recent master branch build is available at http://asok16.cit.tu-berlin.de:8081.
+We use Jenkins for continous deployment of the project.
+You can find information about each job and, the build status and e.g. console output during the build.
+The dashboard is available at http://asok16.cit.tu-berlin.de:8080/.
 
-As Jenkins is not available from the public internet, it can not be notified by Github about new commits. Instead, Jenkins queries Github every 5 minutes for changes and triggers a new build, if necessary. The dashboard is available at http://asok16.cit.tu-berlin.de:8080/, where one can manually trigger a new build.
+We use two main branches for development: **master** and **dev**.
+* The most recent **master** branch build is available at http://asok16.cit.tu-berlin.de:8081.
+* The most recent **dev** branch build is available at  http://asok16.cit.tu-berlin.de:8082.

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -56,7 +56,7 @@
 
     <!-- build:js scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="../bower_components/jquery/dist/jquery.js"></script>
+    <script src="../bower_components/jquery/jquery.js"></script>
     <script src="../bower_components/lodash/lodash.js"></script>
     <script src="../bower_components/backbone/backbone.js"></script>
     <script src="../bower_components/graphlib/dist/graphlib.core.js"></script>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,37 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <!-- Profile configuration -->
+    <profiles>
+        <!-- The configuration of the development profile -->
+        <profile>
+            <id>dev</id>
+            <properties>
+                <!--
+                        Specifies the build.profile.id property that must be equal than the name of
+                        the directory that contains the profile specific configuration file.
+                        Because the name of the directory that contains the configuration file of the
+                        development profile is dev, we must set the value of the build.profile.id
+                        property to dev.
+                    -->
+                <grunt.task>serve</grunt.task>
+                <build.profile.id>dev</build.profile.id>
+            </properties>
+        </profile>
+        <!-- The configuration of the production profile -->
+        <profile>
+            <id>prod</id>
+            <!-- The development profile is active by default -->
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <grunt.task>build</grunt.task>
+                <build.profile.id>prod</build.profile.id>
+            </properties>
+        </profile>
+    </profiles>
+
     <dependencies>
         <!-- Test -->
         <dependency>
@@ -74,7 +105,7 @@
     </dependencies>
 
     <build>
-      <finalName>ROOT</finalName> <!-- Necesśary for jenkins deployment to have this name -->
+        <finalName>ROOT</finalName> <!-- Necesśary for jenkins deployment to have this name -->
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -115,17 +146,6 @@
                         </configuration>
                     </execution>
 
-                    <!--
-                    <execution>
-                        <id>npm run build</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>run build</arguments>
-                        </configuration>
-                    </execution> -->
-
                     <execution>
                         <id>bower install</id>
                         <goals>
@@ -145,7 +165,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>build --no-color --force</arguments>
+                            <arguments>${grunt.task} --no-color --force</arguments>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
First pull request was for the **master** and not for **dev** branch as we agreed on, but apart from that, both pull requests are the same.

Invode the dev profile via `mvn jetty:run -P dev`. This will instruct grunt to start its own build-in webserver, but this means as well, that the complete jetty environment with the backend will not be available.

I added the changes to the README.md.

The index.html changes came automatically, I guess from the new profile.